### PR TITLE
Feature/additional chart menus

### DIFF
--- a/src/api-calls.js
+++ b/src/api-calls.js
@@ -87,3 +87,4 @@ export const updateContactAssignment = (contactID, roleID, incidentID) => {
   })
   .catch(error => console.log('api errros:', error))
 }
+

--- a/src/api-calls.js
+++ b/src/api-calls.js
@@ -80,8 +80,9 @@ export const getIncidentContacts = (incidentID) => {
   .catch(error => console.log('api errors:', error))
 }
 
-export const updateContactAssignment = (contactID, roleID, incidentID) => {
-  return axios.put(`${baseURL}/contacts/${contactID}`, {'incident_id': incidentID, 'incident_role': roleID})
+export const updateContactAssignment = (contactID, roleID, incidentID, parentID, incidentTitle) => {
+  console.log(contactID, roleID, incidentID, parentID, incidentTitle)
+  return axios.put(`${baseURL}/contacts/${contactID}`, {'incident_id': incidentID, 'incident_role': roleID, 'incident_parent': parentID, 'incident_title': incidentTitle})
   .then(response => {
     return response.data
   })

--- a/src/components/AddNode/AddNode.js
+++ b/src/components/AddNode/AddNode.js
@@ -1,44 +1,136 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { useSelector } from 'react-redux'
 import { Modal } from 'react-bootstrap';
+import { getAllContacts, updateContactAssignment } from '../../api-calls';
+import { returnContactAvatar } from '../../utils';
 
 const AddNode = (props) => {
-
   console.log(props)
+  const [availableContacts, setAvailableContacts] = useState([])
+  const [selectedContact, setSelectedContact] = useState(null)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [nodeName, setNodeName] = useState('')
+  const [nodeType, setNodeType] = useState('')
+  const [confirmationVisibility, setConfirmationVisibility] = useState(false)
+  const userID = useSelector(state => state.user.user.id)
 
-  return (
-    <Modal
+  const refreshContacts = () => {
+    getAllContacts(userID)
+    .then(response => setAvailableContacts(response.contacts.filter(contact => contact.incident_id === null)))
+  }
+
+  useEffect(() => {
+    refreshContacts()
+  }, [])
+
+  const compileAvailableContacts = (qry) => {
+    return availableContacts.filter(contact => {
+      return contact.name.toLowerCase().includes(qry)
+    }).map(contact => {
+      return (
+        <div key={contact.id} onClick={() => setSelectedContact(contact)}>
+          {returnContactAvatar(contact.contact_type)} {contact.name} - {contact.jobtitle} - {contact.organization}
+        </div>
+      )
+    })
+  }
+
+  const assignContactToRole = () => {
+    const incidentTitle = nodeName + nodeType
+    updateContactAssignment(selectedContact.id, Date.now(), props.incidentID, props.parent.id, incidentTitle)
+    .then (response => {
+      if (response.status === 'updated') {
+        setSelectedContact(null)
+        refreshContacts()
+        setConfirmationVisibility(false)
+        props.onHide()
+      }
+    })
+  }
+
+  const validateForm = e => {
+    e.preventDefault()
+    if (!selectedContact || !nodeName) {
+      console.log('error')
+    } else {
+      setConfirmationVisibility(true)
+    }
+  }
+
+  if (confirmationVisibility) {
+    return (
+      <Modal
       {...props}
       size="lg"
       aria-labelledby="contained-modal-title-vcenter"
       backdrop="static"
     >
-      <Modal.Header closeButton>
-        <Modal.Title>
-          Add Node menu
-        </Modal.Title>
-      </Modal.Header>
       <Modal.Body>
-        <form>
-
-          <select>
-            <option>Branch</option>
-            <option>Division</option>
-            <option>Group</option>
-            <option>Unit</option>
-            <option>Strike Team</option>
-            <option>Task Force</option>
-            <option>Single Resource</option>
-            <option>Other</option>
-          </select>
-
-          <input placeholder="resource name"></input>
-
-        </form>
-          
-
-        </Modal.Body>
+        <div>Assign {selectedContact.name} - {selectedContact.organization} as {nodeName} {nodeType} under {props.parent.title} {props.parent.contact.name} ?</div>
+        <button onClick={assignContactToRole}>CONFIRM</button>
+      </Modal.Body>
     </Modal>
-  )
+    )
+  } else {
+    return (
+      <Modal
+        {...props}
+        size="lg"
+        aria-labelledby="contained-modal-title-vcenter"
+        backdrop="static"
+      >
+        <Modal.Header closeButton>
+          <Modal.Title>
+            Add Node menu
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <form>
+  
+            <select
+              onChange={e => setNodeType(e.target.value)}
+              value={nodeType}
+            >
+              <option>Branch</option>
+              <option>Division</option>
+              <option>Group</option>
+              <option>Unit</option>
+              <option>Strike Team</option>
+              <option>Task Force</option>
+              <option>Single Resource</option>
+              <option value=''>Other</option>
+            </select>
+  
+            <input 
+              type='text'
+              placeholder="resource name"
+              onChange={e => setNodeName(e.target.value)}
+              value={nodeName}
+            />
+  
+            {selectedContact && <div>{selectedContact.name} - {selectedContact.organization}</div>}
+  
+            <button onClick={e => validateForm(e)}>
+              SUBMIT
+            </button>
+  
+            <hr></hr>
+  
+            <input
+              type='text'
+              placeholder='search'
+              onChange={e => setSearchQuery(e.target.value)}
+            />
+  
+            {compileAvailableContacts(searchQuery.toLowerCase())}
+  
+          </form>
+            
+  
+          </Modal.Body>
+      </Modal>
+    )
+  }
 
 }
 

--- a/src/components/AddNode/AddNode.js
+++ b/src/components/AddNode/AddNode.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { Modal } from 'react-bootstrap';
+
+const AddNode = (props) => {
+
+  console.log(props)
+
+  return (
+    <Modal
+      {...props}
+      size="lg"
+      aria-labelledby="contained-modal-title-vcenter"
+      backdrop="static"
+    >
+      <Modal.Header closeButton>
+        <Modal.Title>
+          Add Node menu
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <form>
+
+          <select>
+            <option>Branch</option>
+            <option>Division</option>
+            <option>Group</option>
+            <option>Unit</option>
+            <option>Strike Team</option>
+            <option>Task Force</option>
+            <option>Single Resource</option>
+            <option>Other</option>
+          </select>
+
+          <input placeholder="resource name"></input>
+
+        </form>
+          
+
+        </Modal.Body>
+    </Modal>
+  )
+
+}
+
+export default AddNode

--- a/src/components/AddNode/AddNode.js
+++ b/src/components/AddNode/AddNode.js
@@ -40,9 +40,9 @@ const AddNode = (props) => {
     updateContactAssignment(selectedContact.id, Date.now(), props.incidentID, props.parent.id, incidentTitle)
     .then (response => {
       if (response.status === 'updated') {
+        setConfirmationVisibility(false)
         setSelectedContact(null)
         refreshContacts()
-        setConfirmationVisibility(false)
         props.onHide()
       }
     })

--- a/src/components/AssignRoleMenu/AssignRoleMenu.js
+++ b/src/components/AssignRoleMenu/AssignRoleMenu.js
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux'
 import { Modal } from 'react-bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import { getAllContacts, updateContactAssignment } from '../../api-calls'
-import { BiUserCircle } from 'react-icons/bi'
+import { returnContactAvatar } from '../../utils'
 
 const AssignRoleMenu = (props) => {
 
@@ -19,7 +19,7 @@ const AssignRoleMenu = (props) => {
 
   useEffect(() => {
     refreshContacts()
-  }, [])
+  }, [refreshContacts])
 
   const compileAvailableContacts = (qry) => {
     return availableContacts.filter(contact => {
@@ -27,7 +27,7 @@ const AssignRoleMenu = (props) => {
     }).map(contact => {
       return (
         <div key={contact.id} onClick={() => setSelectedContact(contact)}>
-          <BiUserCircle /> {contact.name} - {contact.jobtitle} - {contact.organization}
+          {returnContactAvatar(contact.contact_type)} {contact.name} - {contact.jobtitle} - {contact.organization}
         </div>
       )
     })

--- a/src/components/AssignRoleMenu/AssignRoleMenu.js
+++ b/src/components/AssignRoleMenu/AssignRoleMenu.js
@@ -13,6 +13,7 @@ const AssignRoleMenu = (props) => {
   const userID = useSelector(state => state.user.user.id)
 
   const refreshContacts = () => {
+    console.log('test')
     getAllContacts(userID)
     .then(response => setAvailableContacts(response.contacts.filter(contact => contact.incident_id === null && contact.contact_type === 'Person')))
   }
@@ -24,10 +25,9 @@ const AssignRoleMenu = (props) => {
   const compileAvailableContacts = (qry) => {
     return availableContacts.filter(contact => {
       return contact.name.toLowerCase().includes(qry)
-    })
-    .map(contact => {
+    }).map(contact => {
       return (
-        <div onClick={() => setSelectedContact(contact)}>
+        <div key={contact.id} onClick={() => setSelectedContact(contact)}>
           <BiUserCircle /> {contact.name} - {contact.jobtitle} - {contact.organization}
         </div>
       )

--- a/src/components/AssignRoleMenu/AssignRoleMenu.js
+++ b/src/components/AssignRoleMenu/AssignRoleMenu.js
@@ -13,7 +13,6 @@ const AssignRoleMenu = (props) => {
   const userID = useSelector(state => state.user.user.id)
 
   const refreshContacts = () => {
-    console.log('test')
     getAllContacts(userID)
     .then(response => setAvailableContacts(response.contacts.filter(contact => contact.incident_id === null && contact.contact_type === 'Person')))
   }

--- a/src/components/ChartEditor/ChartEditor.css
+++ b/src/components/ChartEditor/ChartEditor.css
@@ -6,3 +6,14 @@
 .ContactTemplate {
   border: 2px solid white;
 }
+
+.UnassignedContactTemplate {
+  border: 2px solid darkslateblue;
+}
+
+.UnassignedContactTemplate > .ContactDescription,
+.UnassignedContactTemplate > .ContactPhone,
+.UnassignedContactTemplate > .ContactEmail,
+.UnassignedContactTemplate > .ContactTitleBackground > .ContactTitle {
+  color: darkslateblue;
+}

--- a/src/components/ChartEditor/ChartEditor.css
+++ b/src/components/ChartEditor/ChartEditor.css
@@ -1,5 +1,5 @@
 .chart-editor {
-  height: 1000px;
+  height: 2000px;
   border-top: 2px solid white;
 }
 

--- a/src/components/ChartEditor/ChartEditor.css
+++ b/src/components/ChartEditor/ChartEditor.css
@@ -1,5 +1,5 @@
 .chart-editor {
-  height: 700px;
+  height: 1000px;
   border-top: 2px solid white;
 }
 

--- a/src/components/ChartEditor/ChartEditor.js
+++ b/src/components/ChartEditor/ChartEditor.js
@@ -275,6 +275,7 @@ export default class ChartEditor extends Component {
         {this.state.reassignMenu.isVisible && <ReassignMenu
           show={this.state.reassignMenu.isVisible}
           role={this.state.reassignMenu.role}
+          incidentID={this.state.incidentID}
           onHide={() => {
             this.setState({ reassignMenu: { isVisible: false, role: null } })
             this.refreshContacts()

--- a/src/components/ChartEditor/ChartEditor.js
+++ b/src/components/ChartEditor/ChartEditor.js
@@ -287,13 +287,13 @@ export default class ChartEditor extends Component {
           }}
           animation={false}
         />}
-        <AddNode
+        {this.state.addNode.isVisible && <AddNode
           show={this.state.addNode.isVisible}
           onHide={() => this.setState({ addNode: { isVisible: false, parent: null } })}
           parent={this.state.addNode.parent}
           incidentID={this.state.incidentID}
           animation={false}
-        />
+        />}
       </div>
     )
   }

--- a/src/components/ChartEditor/ChartEditor.js
+++ b/src/components/ChartEditor/ChartEditor.js
@@ -3,7 +3,7 @@ import { getIncidentContacts } from '../../api-calls'
 import { OrgDiagram } from 'basicprimitivesreact'
 import { PageFitMode, GroupByType, Enabled, ItemType, AdviserPlacementType, ChildrenPlacementType } from 'basicprimitives';
 import './ChartEditor.css'
-import { AiOutlineUserAdd, AiOutlineUserDelete, AiOutlineUserSwitch, AiOutlineCluster, AiOutlineDelete, AiFillTablet } from 'react-icons/ai'
+import { AiOutlineUserAdd, AiOutlineUserDelete, AiOutlineUserSwitch, AiOutlineCluster, AiOutlineDelete } from 'react-icons/ai'
 import AssignRoleMenu from '../AssignRoleMenu/AssignRoleMenu';
 import UnassignMenu from '../UnassignMenu/UnassignMenu'
 import ReassignMenu from '../ReassignMenu/ReassignMenu'
@@ -303,8 +303,8 @@ export default class ChartEditor extends Component {
               {itemConfig.contact && <button onClick={() => this.setState({ reassignMenu: { isVisible: true, role: itemConfig } })}>
                 <AiOutlineUserSwitch />
               </button>}
-              {itemConfig.contact && <button onClick={() => this.setState({ unassignMenu: { isVisible: true, role: itemConfig } })}>
-                <AiOutlineUserDelete />
+              {itemConfig.contact && <button onClick={() => console.log('delete this node!')}>
+                <AiOutlineDelete />
               </button>}
               {itemConfig.contact && <button onClick={() => this.setState({ addNode: { isVisible: true, parent: itemConfig } })}>
                 <AiOutlineCluster />
@@ -350,7 +350,10 @@ export default class ChartEditor extends Component {
         />}
         {this.state.addNode.isVisible && <AddNode
           show={this.state.addNode.isVisible}
-          onHide={() => this.setState({ addNode: { isVisible: false, parent: null } })}
+          onHide={() => {
+            this.setState({ addNode: { isVisible: false, parent: null } })
+            this.refreshContacts()
+          }}
           parent={this.state.addNode.parent}
           incidentID={this.state.incidentID}
           animation={false}

--- a/src/components/ChartEditor/ChartEditor.js
+++ b/src/components/ChartEditor/ChartEditor.js
@@ -7,6 +7,7 @@ import { AiOutlineUserAdd, AiOutlineUserDelete, AiOutlineUserSwitch, AiOutlineCl
 import { BiUserCircle } from 'react-icons/bi'
 import AssignRoleMenu from '../AssignRoleMenu/AssignRoleMenu';
 import UnassignMenu from '../UnassignMenu/UnassignMenu'
+import ReassignMenu from '../ReassignMenu/ReassignMenu'
 
 export default class ChartEditor extends Component {
   constructor({ incidentID }) {
@@ -18,6 +19,10 @@ export default class ChartEditor extends Component {
         role: null
       },
       unassignMenu: {
+        isVisible: false,
+        role: null
+      },
+      reassignMenu: {
         isVisible: false,
         role: null
       },
@@ -168,7 +173,7 @@ export default class ChartEditor extends Component {
               {!itemConfig.contact && <button onClick={() => this.setState({ assignmentMenu: { isVisible: true, role: itemConfig } })}>
                 <AiOutlineUserAdd />
               </button>}
-              {itemConfig.contact && <button onClick={() => console.log('this button will reassign the incident commander')}>
+              {itemConfig.contact && <button onClick={() => this.setState({ reassignMenu: { isVisible: true, role: itemConfig } })}>
                 <AiOutlineUserSwitch />
               </button>}
             </>
@@ -197,7 +202,7 @@ export default class ChartEditor extends Component {
               {!itemConfig.contact && <button onClick={() => this.setState({ assignmentMenu: { isVisible: true, role: itemConfig } })}>
                 <AiOutlineUserAdd />
               </button>}
-              {itemConfig.contact && <button onClick={() => console.log('this button will reassign this node')}>
+              {itemConfig.contact && <button onClick={() => this.setState({ reassignMenu: { isVisible: true, role: itemConfig } })}>
                 <AiOutlineUserSwitch />
               </button>}
               {itemConfig.contact  && <button onClick={() => this.setState({ unassignMenu: { isVisible: true, role: itemConfig } })}>
@@ -229,10 +234,10 @@ export default class ChartEditor extends Component {
               {!itemConfig.contact && <button onClick={() => this.setState({ assignmentMenu: { isVisible: true, role: itemConfig } })}>
                 <AiOutlineUserAdd />
               </button>}
-              {itemConfig.contact && <button onClick={() => console.log('this button will reassign this node')}>
+              {itemConfig.contact && <button onClick={() => this.setState({ reassignMenu: { isVisible: true, role: itemConfig } })}>
                 <AiOutlineUserSwitch />
               </button>}
-              {itemConfig.contact && <button onClick={() => console.log('this button will unassign this node')}>
+              {itemConfig.contact && <button onClick={() => this.setState({ unassignMenu: { isVisible: true, role: itemConfig } })}>
                 <AiOutlineUserDelete />
               </button>}
               {itemConfig.contact && <button onClick={() => console.log('this button will add a new node to this parent')}>
@@ -262,11 +267,20 @@ export default class ChartEditor extends Component {
           show={this.state.unassignMenu.isVisible}
           role={this.state.unassignMenu.role}
           onHide={() => {
-            this.setState({ unassignMenu: {isVisible: false, role: null } })
+            this.setState({ unassignMenu: { isVisible: false, role: null } })
             this.refreshContacts()
           }}
           animation={false}         
         />
+        {this.state.reassignMenu.isVisible && <ReassignMenu
+          show={this.state.reassignMenu.isVisible}
+          role={this.state.reassignMenu.role}
+          onHide={() => {
+            this.setState({ reassignMenu: { isVisible: false, role: null } })
+            this.refreshContacts()
+          }}
+          animation={false}
+        />}
       </div>
     )
   }

--- a/src/components/ChartEditor/ChartEditor.js
+++ b/src/components/ChartEditor/ChartEditor.js
@@ -123,22 +123,47 @@ export default class ChartEditor extends Component {
   }
 
   refreshContacts() {
+    let workingArray = this.state.incidentContacts
     getIncidentContacts(this.state.incidentID)
-    .then(data => {
-      let workingArray = this.state.incidentContacts
-      workingArray.forEach(role => {
-        if (data.contacts.find(contact => contact.incident_role === role.id)) {
-          role.contact = data.contacts.find(contact => contact.incident_role === role.id)
-        } else {
-          role.contact = null
+    .then(data => data.contacts.map(contact => {
+      let match = workingArray.find(role => role.id === contact.incident_role)
+      if (match) {
+        match.contact = contact
+      } else {
+        let node = {
+          id: contact.incident_role,
+          parent: contact.incident_parent,
+          title: contact.incident_title,
+          contact: contact,
+          templateName: 'section_node',
+          isVisible: false
         }
-      })
+        workingArray.push(node)
+      }
       if (workingArray[0].contact) {
-        workingArray.forEach(contact => contact.title !=='aggregator' ? contact.isVisible = true : null)
+        workingArray.forEach(contact => contact.title !== 'aggregator' ? contact.isVisible = true : null)
       }
       this.setState({ incidentContacts: workingArray })
-    })
+    }))
   }
+
+  // refreshContacts() {
+  //   getIncidentContacts(this.state.incidentID)
+  //   .then(data => {
+  //     let workingArray = this.state.incidentContacts
+  //     workingArray.forEach(role => {
+  //       if (data.contacts.find(contact => contact.incident_role === role.id)) {
+  //         role.contact = data.contacts.find(contact => contact.incident_role === role.id)
+  //       } else {
+  //         role.contact = null
+  //       }
+  //     })
+  //     if (workingArray[0].contact) {
+  //       workingArray.forEach(contact => contact.title !=='aggregator' ? contact.isVisible = true : null)
+  //     }
+  //     this.setState({ incidentContacts: workingArray })
+  //   })
+  // }
 
   componentDidMount() {
     this.refreshContacts()

--- a/src/components/ChartEditor/ChartEditor.js
+++ b/src/components/ChartEditor/ChartEditor.js
@@ -8,6 +8,7 @@ import { BiUserCircle } from 'react-icons/bi'
 import AssignRoleMenu from '../AssignRoleMenu/AssignRoleMenu';
 import UnassignMenu from '../UnassignMenu/UnassignMenu'
 import ReassignMenu from '../ReassignMenu/ReassignMenu'
+import { returnContactAvatar } from '../../utils'
 
 export default class ChartEditor extends Component {
   constructor({ incidentID }) {
@@ -160,7 +161,7 @@ export default class ChartEditor extends Component {
                   <div className="ContactTitle">{itemConfig.title}</div>
                 </div>
                 <div className="ContactPhotoFrame">
-                  <BiUserCircle />
+                  {itemConfig.contact ? returnContactAvatar(itemConfig.contact.contact_type) : null}
                 </div>
                 <div className="ContactDescription">{itemConfig.contact ? itemConfig.contact.name : 'Unassigned'}</div>
                 <div className="ContactPhone">Phone: {itemConfig.contact ? itemConfig.contact.phone : ''}</div>
@@ -184,12 +185,12 @@ export default class ChartEditor extends Component {
           itemSize: { width: 220, height: 150 },
           onItemRender: ({ context: itemConfig }) => {
             return (
-              <div className="ContactTemplate">
+              <div className={itemConfig.contact ? 'ContactTemplate' : 'UnassignedContactTemplate'}>
                 <div className="ContactTitleBackground">
                   <div className="ContactTitle">{itemConfig.title}</div>
                 </div>
                 <div className="ContactPhotoFrame">
-                  <BiUserCircle />
+                  {itemConfig.contact ? returnContactAvatar(itemConfig.contact.contact_type) : null}
                 </div>
                 <div className="ContactDescription">{itemConfig.contact ? itemConfig.contact.name : 'Unassigned'}</div>
                 <div className="ContactPhone">Phone: {itemConfig.contact ? itemConfig.contact.phone : ''}</div>
@@ -215,13 +216,14 @@ export default class ChartEditor extends Component {
           name: 'section_commander',
           itemSize: { width: 220, height: 150 },
           onItemRender: ({ context: itemConfig }) => {
+            console.log(itemConfig)
             return (
-              <div className="ContactTemplate">
+              <div className={itemConfig.contact ? 'ContactTemplate' : 'UnassignedContactTemplate'}>
                 <div className="ContactTitleBackground">
                   <div className="ContactTitle">{itemConfig.title}</div>
                 </div>
                 <div className="ContactPhotoFrame">
-                  <BiUserCircle />
+                  {itemConfig.contact ? returnContactAvatar(itemConfig.contact.contact_type) : null}
                 </div>
                 <div className="ContactDescription">{itemConfig.contact ? itemConfig.contact.name : 'Unassigned'}</div>
                 <div className="ContactPhone">Phone: {itemConfig.contact ? itemConfig.contact.phone : ''}</div>

--- a/src/components/ChartEditor/ChartEditor.js
+++ b/src/components/ChartEditor/ChartEditor.js
@@ -124,6 +124,7 @@ export default class ChartEditor extends Component {
 
   refreshContacts() {
     let workingArray = this.state.incidentContacts
+    workingArray.forEach(role => role.contact = null)
     getIncidentContacts(this.state.incidentID)
     .then(data => data.contacts.map(contact => {
       let match = workingArray.find(role => role.id === contact.incident_role)
@@ -243,6 +244,41 @@ export default class ChartEditor extends Component {
         },
         {
           name: 'section_commander',
+          itemSize: { width: 220, height: 150 },
+          onItemRender: ({ context: itemConfig }) => {
+            return (
+              <div className={itemConfig.contact ? 'ContactTemplate' : 'UnassignedContactTemplate'}>
+                <div className="ContactTitleBackground">
+                  <div className="ContactTitle">{itemConfig.title}</div>
+                </div>
+                <div className="ContactPhotoFrame">
+                  {itemConfig.contact ? returnContactAvatar(itemConfig.contact.contact_type) : null}
+                </div>
+                <div className="ContactDescription">{itemConfig.contact ? itemConfig.contact.name : 'Unassigned'}</div>
+                <div className="ContactPhone">Phone: {itemConfig.contact ? itemConfig.contact.phone : ''}</div>
+                <div className="ContactEmail">Email: {itemConfig.contact ? itemConfig.contact.email : ''}</div>
+              </div> 
+            )
+          },
+          onButtonsRender: ({ context: itemConfig }) => {
+            return <>
+              {!itemConfig.contact && <button onClick={() => this.setState({ assignmentMenu: { isVisible: true, role: itemConfig } })}>
+                <AiOutlineUserAdd />
+              </button>}
+              {itemConfig.contact && <button onClick={() => this.setState({ reassignMenu: { isVisible: true, role: itemConfig } })}>
+                <AiOutlineUserSwitch />
+              </button>}
+              {itemConfig.contact && <button onClick={() => this.setState({ unassignMenu: { isVisible: true, role: itemConfig } })}>
+                <AiOutlineUserDelete />
+              </button>}
+              {itemConfig.contact && <button onClick={() => this.setState({ addNode: { isVisible: true, parent: itemConfig } })}>
+                <AiOutlineCluster />
+              </button>}
+            </>
+          }
+        },
+        {
+          name: 'section_node',
           itemSize: { width: 220, height: 150 },
           onItemRender: ({ context: itemConfig }) => {
             return (

--- a/src/components/ChartEditor/ChartEditor.js
+++ b/src/components/ChartEditor/ChartEditor.js
@@ -3,7 +3,7 @@ import { getIncidentContacts } from '../../api-calls'
 import { OrgDiagram } from 'basicprimitivesreact'
 import { PageFitMode, GroupByType, Enabled, ItemType, AdviserPlacementType, ChildrenPlacementType } from 'basicprimitives';
 import './ChartEditor.css'
-import { AiOutlineUserAdd, AiOutlineUserDelete, AiOutlineUserSwitch, AiOutlineCluster, AiOutlineDelete } from 'react-icons/ai'
+import { AiOutlineUserAdd, AiOutlineUserDelete, AiOutlineUserSwitch, AiOutlineCluster, AiOutlineDelete, AiFillTablet } from 'react-icons/ai'
 import { BiUserCircle } from 'react-icons/bi'
 import AssignRoleMenu from '../AssignRoleMenu/AssignRoleMenu';
 import UnassignMenu from '../UnassignMenu/UnassignMenu'
@@ -112,21 +112,30 @@ export default class ChartEditor extends Component {
     }
   }
 
-  componentDidMount() {
+  refreshContacts() {
     getIncidentContacts(this.state.incidentID)
-    .then(data => data.contacts.forEach(contact => {
+    .then(data => {
       let workingArray = this.state.incidentContacts
-      let updateRole = workingArray.find(role => role.id === contact.incident_role)
-      updateRole.contact = contact
-      if (updateRole.id === 0) {
+      workingArray.forEach(role => {
+        if (data.contacts.find(contact => contact.incident_role === role.id)) {
+          role.contact = data.contacts.find(contact => contact.incident_role === role.id)
+        } else {
+          role.contact = null
+        }
+      })
+      if (workingArray[0].contact) {
         workingArray.forEach(contact => contact.title !=='aggregator' ? contact.isVisible = true : null)
       }
       this.setState({ incidentContacts: workingArray })
-    }))
+    })
+  }
+
+  componentDidMount() {
+    this.refreshContacts()
   }
 
   render() {
-    console.log(this.state)
+
     const config = {
       pageFitMode: PageFitMode.FitToPage,
       cursorItem: 0,
@@ -239,22 +248,22 @@ export default class ChartEditor extends Component {
     return (
       <div className='chart-editor'>
         <OrgDiagram centerOnCursor={true} config={config} />
-        <AssignRoleMenu 
+        {this.state.assignmentMenu.isVisible && <AssignRoleMenu 
           show={this.state.assignmentMenu.isVisible} 
           role={this.state.assignmentMenu.role}
           incidentID={this.state.incidentID}
           onHide={() => {
             this.setState({ assignmentMenu: { isVisible: false, role: null } })
-            this.componentDidMount()
+            this.refreshContacts()
           }} 
           animation={false} 
-        />
+        />}
         <UnassignMenu
           show={this.state.unassignMenu.isVisible}
           role={this.state.unassignMenu.role}
           onHide={() => {
             this.setState({ unassignMenu: {isVisible: false, role: null } })
-            this.componentDidMount()
+            this.refreshContacts()
           }}
           animation={false}         
         />

--- a/src/components/ChartEditor/ChartEditor.js
+++ b/src/components/ChartEditor/ChartEditor.js
@@ -4,10 +4,10 @@ import { OrgDiagram } from 'basicprimitivesreact'
 import { PageFitMode, GroupByType, Enabled, ItemType, AdviserPlacementType, ChildrenPlacementType } from 'basicprimitives';
 import './ChartEditor.css'
 import { AiOutlineUserAdd, AiOutlineUserDelete, AiOutlineUserSwitch, AiOutlineCluster, AiOutlineDelete, AiFillTablet } from 'react-icons/ai'
-import { BiUserCircle } from 'react-icons/bi'
 import AssignRoleMenu from '../AssignRoleMenu/AssignRoleMenu';
 import UnassignMenu from '../UnassignMenu/UnassignMenu'
 import ReassignMenu from '../ReassignMenu/ReassignMenu'
+import AddNode from '../AddNode/AddNode'
 import { returnContactAvatar } from '../../utils'
 
 export default class ChartEditor extends Component {
@@ -26,6 +26,10 @@ export default class ChartEditor extends Component {
       reassignMenu: {
         isVisible: false,
         role: null
+      },
+      addNode: {
+        isVisible: false,
+        parent: null
       },
       incidentContacts: [
         {
@@ -216,7 +220,6 @@ export default class ChartEditor extends Component {
           name: 'section_commander',
           itemSize: { width: 220, height: 150 },
           onItemRender: ({ context: itemConfig }) => {
-            console.log(itemConfig)
             return (
               <div className={itemConfig.contact ? 'ContactTemplate' : 'UnassignedContactTemplate'}>
                 <div className="ContactTitleBackground">
@@ -242,7 +245,7 @@ export default class ChartEditor extends Component {
               {itemConfig.contact && <button onClick={() => this.setState({ unassignMenu: { isVisible: true, role: itemConfig } })}>
                 <AiOutlineUserDelete />
               </button>}
-              {itemConfig.contact && <button onClick={() => console.log('this button will add a new node to this parent')}>
+              {itemConfig.contact && <button onClick={() => this.setState({ addNode: { isVisible: true, parent: itemConfig } })}>
                 <AiOutlineCluster />
               </button>}
             </>
@@ -284,6 +287,13 @@ export default class ChartEditor extends Component {
           }}
           animation={false}
         />}
+        <AddNode
+          show={this.state.addNode.isVisible}
+          onHide={() => this.setState({ addNode: { isVisible: false, parent: null } })}
+          parent={this.state.addNode.parent}
+          incidentID={this.state.incidentID}
+          animation={false}
+        />
       </div>
     )
   }

--- a/src/components/NewContactForm/NewContactForm.js
+++ b/src/components/NewContactForm/NewContactForm.js
@@ -2,6 +2,10 @@ import React, { useState } from 'react'
 import Input from 'react-phone-number-input/input'
 import { useSelector } from 'react-redux'
 import { createNewContact } from '../../api-calls' 
+import { AiOutlineUser, AiOutlineTeam } from 'react-icons/ai'
+import { FiTruck } from 'react-icons/fi'
+import { GiHelicopter, GiCrane, GiSittingDog } from 'react-icons/gi'
+import { IoMdBoat } from 'react-icons/io'
 import './NewContactForm.css'
 
 const NewContactForm = () => {
@@ -91,13 +95,13 @@ const NewContactForm = () => {
         value={type}
       >
         <option value=''>--select--</option>
-        <option>Person</option>
-        <option>Team</option>
-        <option>Vehicle</option>
-        <option>Aircraft</option>
-        <option>Watercraft</option>
-        <option>Machinery</option>
-        <option>Animal</option>
+        <option>{<AiOutlineUser />}Person</option>
+        <option><AiOutlineTeam />Team</option>
+        <option><FiTruck />Vehicle</option>
+        <option><GiHelicopter />Aircraft</option>
+        <option><IoMdBoat />Watercraft</option>
+        <option><GiCrane />Machinery</option>
+        <option><GiSittingDog />Animal</option>
       </select>
 
       <label htmlFor="name">{type === 'Person' ? 'Name:' : 'Asset Name:'}</label>

--- a/src/components/NewContactForm/NewContactForm.js
+++ b/src/components/NewContactForm/NewContactForm.js
@@ -2,10 +2,6 @@ import React, { useState } from 'react'
 import Input from 'react-phone-number-input/input'
 import { useSelector } from 'react-redux'
 import { createNewContact } from '../../api-calls' 
-import { AiOutlineUser, AiOutlineTeam } from 'react-icons/ai'
-import { FiTruck } from 'react-icons/fi'
-import { GiHelicopter, GiCrane, GiSittingDog } from 'react-icons/gi'
-import { IoMdBoat } from 'react-icons/io'
 import './NewContactForm.css'
 
 const NewContactForm = () => {

--- a/src/components/NewContactForm/NewContactForm.js
+++ b/src/components/NewContactForm/NewContactForm.js
@@ -95,13 +95,13 @@ const NewContactForm = () => {
         value={type}
       >
         <option value=''>--select--</option>
-        <option>{<AiOutlineUser />}Person</option>
-        <option><AiOutlineTeam />Team</option>
-        <option><FiTruck />Vehicle</option>
-        <option><GiHelicopter />Aircraft</option>
-        <option><IoMdBoat />Watercraft</option>
-        <option><GiCrane />Machinery</option>
-        <option><GiSittingDog />Animal</option>
+        <option>Person</option>
+        <option>Team</option>
+        <option>Vehicle</option>
+        <option>Aircraft</option>
+        <option>Watercraft</option>
+        <option>Machinery</option>
+        <option>Animal</option>
       </select>
 
       <label htmlFor="name">{type === 'Person' ? 'Name:' : 'Asset Name:'}</label>

--- a/src/components/ReassignMenu/ReassignMenu.js
+++ b/src/components/ReassignMenu/ReassignMenu.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import { Modal } from 'react-bootstrap';
+
+const ReassignMenu = (props) => {
+  
+  console.log(props)
+  
+  return (
+    <Modal
+      {...props}
+      size="lg"
+      aria-labelledby="contained-modal-title-vcenter"
+      backdrop="static"
+    >
+        <Modal.Header closeButton>
+          <Modal.Title id="contained-modal-title-vcenter">
+            Replace {props.role.contact.name} as {props.role.title}
+          </Modal.Title>
+        </Modal.Header>
+    </Modal>
+  )
+}
+
+export default ReassignMenu

--- a/src/components/ReassignMenu/ReassignMenu.js
+++ b/src/components/ReassignMenu/ReassignMenu.js
@@ -1,24 +1,97 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
+import { useSelector } from 'react-redux'
 import { Modal } from 'react-bootstrap';
+import { getAllContacts, updateContactAssignment } from '../../api-calls'
+import { returnContactAvatar } from '../../utils'
 
 const ReassignMenu = (props) => {
-  
   console.log(props)
+  const [availableContacts, setAvailableContacts] = useState([])
+  const [selectedContact, setSelectedContact] = useState(null)
+  const [searchQuery, setSearchQuery] = useState('')
+  const userID = useSelector(state => state.user.user.id)
   
-  return (
-    <Modal
-      {...props}
-      size="lg"
-      aria-labelledby="contained-modal-title-vcenter"
-      backdrop="static"
-    >
+  const refreshContacts = () => {
+    getAllContacts(userID)
+    .then(response => setAvailableContacts(response.contacts.filter(contact => contact.incident_id === null && contact.contact_type === 'Person')))
+  }
+
+  useEffect(() => {
+    refreshContacts()
+  }, [])
+
+  const compileAvailableContacts = (qry) => {
+    return availableContacts.filter(contact => {
+      return contact.name.toLowerCase().includes(qry)
+    }).map(contact => {
+      return (
+        <div key={contact.id} onClick={() => setSelectedContact(contact)}>
+          {returnContactAvatar(contact.contact_type)} {contact.name} - {contact.jobtitle} - {contact.organization}
+        </div>
+      )
+    })
+  }
+
+  const reassignContact = () => {
+    Promise.all([
+      updateContactAssignment(selectedContact.id, props.role.id, props.incidentID),
+      updateContactAssignment(props.role.contact.id, null, null) 
+    ])
+    .then(response => {
+      if (response[0].status === "updated" && response[1].status === "updated") {
+        setSelectedContact(null)
+        refreshContacts()
+        props.onHide()
+      }
+    })
+  }
+  
+  if (props.show && !selectedContact) {
+    return (
+      <Modal
+        {...props}
+        size="lg"
+        aria-labelledby="contained-modal-title-vcenter"
+        backdrop="static"
+      >
         <Modal.Header closeButton>
           <Modal.Title id="contained-modal-title-vcenter">
             Replace {props.role.contact.name} as {props.role.title}
           </Modal.Title>
         </Modal.Header>
-    </Modal>
-  )
+        <Modal.Body>
+          <form>
+            <input type="text" placeholder="search" onChange={e => setSearchQuery(e.target.value)} />
+          </form>
+          {compileAvailableContacts(searchQuery.toLowerCase())}
+        </Modal.Body>
+      </Modal>
+    )
+  } else if (props.show && selectedContact) {
+    return (
+      <Modal
+        {...props}
+        size="lg"
+        aria-labelledby="contained-modal-title-vcenter"
+        backdrop="static"
+      >
+        <Modal.Header closeButton>
+          <Modal.Title id="contained-modal-title-vcenter">
+            Replace {props.role.title}?
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <div>Replace {props.role.contact.name} with {selectedContact.name} as {props.role.title}? </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <button onClick={() => reassignContact()}>CONFIRM</button>
+          <button onClick={() => setSelectedContact(null)}>BACK</button>
+        </Modal.Footer>
+      </Modal>
+    )
+  } else {
+    return <></>
+  }
 }
 
 export default ReassignMenu

--- a/src/components/UnassignMenu/UnassignMenu.js
+++ b/src/components/UnassignMenu/UnassignMenu.js
@@ -6,7 +6,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 const UnassignMenu = (props) => {
   
   const unassignContact = () => {
-    console.log('test')
+
     updateContactAssignment(props.role.contact.id, null, null)
     .then(response => {
       if (response.status === 'updated') {
@@ -23,6 +23,8 @@ const UnassignMenu = (props) => {
         aria-labelledby="contained-modal-title-vcenter"
         backdrop="static"
       >
+        <Modal.Header closeButton>
+        </Modal.Header>
         <Modal.Body>
           <p>Unassign {props.role.contact.name} as {props.role.title}?</p>
           <button onClick={unassignContact}>CONFIRM</button>

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,27 @@
+import { AiOutlineUser, AiOutlineTeam } from 'react-icons/ai'
+import { FiTruck } from 'react-icons/fi'
+import { GiHelicopter, GiCrane, GiSittingDog } from 'react-icons/gi'
+import { IoMdBoat } from 'react-icons/io'
+
 export const formatDate = (datetime) => {
   return datetime.slice(0, 15)
+}
+
+export const returnContactAvatar = (contactType) => {
+  switch (contactType) {
+    case 'Person':
+      return <AiOutlineUser />
+    case 'Team':
+      return <AiOutlineTeam />
+    case 'Vehicle':
+      return <FiTruck />
+    case 'Aircraft':
+      return <GiHelicopter />
+    case 'Watercraft':
+      return <IoMdBoat />
+    case 'Machinery':
+      return <GiCrane />
+    case 'Animal':
+      return <GiSittingDog />
+  }
 }


### PR DESCRIPTION
- This PR primarily adds the new Add Node menu to the Chart Editor, allowing the user to create custom nodes under the Section Chiefs.
- The Unassign button will not work for these custom nodes since the custom node cannot persist after page refresh. The unassign button will need to be replaced by a delete button.
- The updateContactAssignment api call was modified to include new parameters necessary to create new custom nodes with different parents and customized titles. Probably a good idea to rework the original Assignment menu so that this api call so these parameters are passed in as well even if not used directly. Will improve consistency.
- Several warnings and errors are still printing to console, mostly around useEffect dependencies and some issue with the IncidentID prop being passed down from the IncidentManager component. These warnings/errors do not appear to affect functionality. Will squash them tomorrow.
- Overall, Chart Editor appears to be working admirably. Needs to be refined and styled but core functionality is mostly there.