### PR TITLE
Fix/chart editor errors warnings

### DIFF
--- a/src/api-calls.js
+++ b/src/api-calls.js
@@ -81,7 +81,6 @@ export const getIncidentContacts = (incidentID) => {
 }
 
 export const updateContactAssignment = (contactID, roleID, incidentID, parentID, incidentTitle) => {
-  console.log(contactID, roleID, incidentID, parentID, incidentTitle)
   return axios.put(`${baseURL}/contacts/${contactID}`, {'incident_id': incidentID, 'incident_role': roleID, 'incident_parent': parentID, 'incident_title': incidentTitle})
   .then(response => {
     return response.data

--- a/src/components/AddNode/AddNode.js
+++ b/src/components/AddNode/AddNode.js
@@ -28,14 +28,19 @@ const AddNode = (props) => {
     }).map(contact => {
       return (
         <div key={contact.id} onClick={() => setSelectedContact(contact)}>
-          {returnContactAvatar(contact.contact_type)} {contact.name} - {contact.jobtitle} - {contact.organization}
+          {returnContactAvatar(contact.contact_type)} {contact.name} - {contact.jobtitle === 'n/a' ? null : `${contact.jobtitle} -`} {contact.organization}
         </div>
       )
     })
   }
 
   const assignContactToRole = () => {
-    const incidentTitle = nodeName + nodeType
+    let incidentTitle;
+    if (!nodeType) {
+      incidentTitle = nodeName
+    } else {
+      incidentTitle = `${nodeName} (${nodeType})`
+    }
     updateContactAssignment(selectedContact.id, Date.now(), props.incident_id, props.parent.id, incidentTitle)
     .then (response => {
       if (response.status === 'updated') {

--- a/src/components/AddNode/AddNode.js
+++ b/src/components/AddNode/AddNode.js
@@ -5,7 +5,6 @@ import { getAllContacts, updateContactAssignment } from '../../api-calls';
 import { returnContactAvatar } from '../../utils';
 
 const AddNode = (props) => {
-  console.log(props)
   const [availableContacts, setAvailableContacts] = useState([])
   const [selectedContact, setSelectedContact] = useState(null)
   const [searchQuery, setSearchQuery] = useState('')
@@ -14,14 +13,13 @@ const AddNode = (props) => {
   const [confirmationVisibility, setConfirmationVisibility] = useState(false)
   const userID = useSelector(state => state.user.user.id)
 
-  const refreshContacts = () => {
-    getAllContacts(userID)
-    .then(response => setAvailableContacts(response.contacts.filter(contact => contact.incident_id === null)))
-  }
-
   useEffect(() => {
+    const refreshContacts = () => {
+      getAllContacts(userID)
+      .then(response => setAvailableContacts(response.contacts.filter(contact => contact.incident_id === null)))
+    }
     refreshContacts()
-  }, [])
+  }, [userID])
 
   const compileAvailableContacts = (qry) => {
     return availableContacts.filter(contact => {
@@ -37,12 +35,12 @@ const AddNode = (props) => {
 
   const assignContactToRole = () => {
     const incidentTitle = nodeName + nodeType
-    updateContactAssignment(selectedContact.id, Date.now(), props.incidentID, props.parent.id, incidentTitle)
+    updateContactAssignment(selectedContact.id, Date.now(), props.incident_id, props.parent.id, incidentTitle)
     .then (response => {
       if (response.status === 'updated') {
         setConfirmationVisibility(false)
         setSelectedContact(null)
-        refreshContacts()
+        // refreshContacts()
         props.onHide()
       }
     })

--- a/src/components/AddNode/AddNode.js
+++ b/src/components/AddNode/AddNode.js
@@ -11,6 +11,7 @@ const AddNode = (props) => {
   const [nodeName, setNodeName] = useState('')
   const [nodeType, setNodeType] = useState('')
   const [confirmationVisibility, setConfirmationVisibility] = useState(false)
+  const [errors, setErrors] = useState([])
   const userID = useSelector(state => state.user.user.id)
 
   useEffect(() => {
@@ -40,7 +41,6 @@ const AddNode = (props) => {
       if (response.status === 'updated') {
         setConfirmationVisibility(false)
         setSelectedContact(null)
-        // refreshContacts()
         props.onHide()
       }
     })
@@ -49,7 +49,10 @@ const AddNode = (props) => {
   const validateForm = e => {
     e.preventDefault()
     if (!selectedContact || !nodeName) {
-      console.log('error')
+      let errorArray = []
+      if (!selectedContact) errorArray.push('Please select a contact to assign to this node')
+      if (!nodeName) errorArray.push('Please enter a name for this node')
+      setErrors(errorArray)
     } else {
       setConfirmationVisibility(true)
     }
@@ -111,6 +114,10 @@ const AddNode = (props) => {
             <button onClick={e => validateForm(e)}>
               SUBMIT
             </button>
+
+            {errors && errors.map(error => {
+              return <p key={error}>{error}</p>
+            })}
   
             <hr></hr>
   

--- a/src/components/AssignRoleMenu/AssignRoleMenu.js
+++ b/src/components/AssignRoleMenu/AssignRoleMenu.js
@@ -12,14 +12,13 @@ const AssignRoleMenu = (props) => {
   const [searchQuery, setSearchQuery] = useState('')
   const userID = useSelector(state => state.user.user.id)
 
-  const refreshContacts = () => {
-    getAllContacts(userID)
-    .then(response => setAvailableContacts(response.contacts.filter(contact => contact.incident_id === null && contact.contact_type === 'Person')))
-  }
-
   useEffect(() => {
+    const refreshContacts = () => {
+      getAllContacts(userID)
+      .then(response => setAvailableContacts(response.contacts.filter(contact => contact.incident_id === null && contact.contact_type === 'Person')))
+    }
     refreshContacts()
-  }, [refreshContacts])
+  }, [userID])
 
   const compileAvailableContacts = (qry) => {
     return availableContacts.filter(contact => {
@@ -34,11 +33,11 @@ const AssignRoleMenu = (props) => {
   }
 
   const assignContactToRole = () => {
-    updateContactAssignment(selectedContact.id, props.role.id, props.incidentID)
+    updateContactAssignment(selectedContact.id, props.role.id, props.incident_id, props.role.parent, props.role.title)
     .then(response => {
       if (response.status === "updated") {
         setSelectedContact(null)
-        refreshContacts()
+        // refreshContacts()
         props.onHide()
       }
     })

--- a/src/components/AssignRoleMenu/AssignRoleMenu.js
+++ b/src/components/AssignRoleMenu/AssignRoleMenu.js
@@ -37,7 +37,6 @@ const AssignRoleMenu = (props) => {
     .then(response => {
       if (response.status === "updated") {
         setSelectedContact(null)
-        // refreshContacts()
         props.onHide()
       }
     })

--- a/src/components/ChartEditor/ChartEditor.css
+++ b/src/components/ChartEditor/ChartEditor.css
@@ -17,3 +17,8 @@
 .UnassignedContactTemplate > .ContactTitleBackground > .ContactTitle {
   color: darkslateblue;
 }
+
+.ContactTitleBackground {
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/components/ChartEditor/ChartEditor.js
+++ b/src/components/ChartEditor/ChartEditor.js
@@ -230,7 +230,7 @@ export default class ChartEditor extends Component {
       if (workingArray[0].contact) {
         workingArray.forEach(contact => contact.title !== 'aggregator' ? contact.isVisible = true : null)
       }
-      this.setState({ incidentContacts: workingArray })
+      return this.setState({ incidentContacts: workingArray })
     }))
   }
 

--- a/src/components/ChartEditor/ChartEditor.js
+++ b/src/components/ChartEditor/ChartEditor.js
@@ -148,24 +148,6 @@ export default class ChartEditor extends Component {
     }))
   }
 
-  // refreshContacts() {
-  //   getIncidentContacts(this.state.incidentID)
-  //   .then(data => {
-  //     let workingArray = this.state.incidentContacts
-  //     workingArray.forEach(role => {
-  //       if (data.contacts.find(contact => contact.incident_role === role.id)) {
-  //         role.contact = data.contacts.find(contact => contact.incident_role === role.id)
-  //       } else {
-  //         role.contact = null
-  //       }
-  //     })
-  //     if (workingArray[0].contact) {
-  //       workingArray.forEach(contact => contact.title !=='aggregator' ? contact.isVisible = true : null)
-  //     }
-  //     this.setState({ incidentContacts: workingArray })
-  //   })
-  // }
-
   componentDidMount() {
     this.refreshContacts()
   }
@@ -268,9 +250,9 @@ export default class ChartEditor extends Component {
               {itemConfig.contact && <button onClick={() => this.setState({ reassignMenu: { isVisible: true, role: itemConfig } })}>
                 <AiOutlineUserSwitch />
               </button>}
-              {itemConfig.contact && <button onClick={() => this.setState({ unassignMenu: { isVisible: true, role: itemConfig } })}>
+              {itemConfig.contact && !this.state.incidentContacts.find(contact => contact.parent === itemConfig.id) ? <button onClick={() => this.setState({ unassignMenu: { isVisible: true, role: itemConfig } })}>
                 <AiOutlineUserDelete />
-              </button>}
+              </button> : null}
               {itemConfig.contact && <button onClick={() => this.setState({ addNode: { isVisible: true, parent: itemConfig } })}>
                 <AiOutlineCluster />
               </button>}
@@ -303,9 +285,9 @@ export default class ChartEditor extends Component {
               {itemConfig.contact && <button onClick={() => this.setState({ reassignMenu: { isVisible: true, role: itemConfig } })}>
                 <AiOutlineUserSwitch />
               </button>}
-              {itemConfig.contact && <button onClick={() => console.log('delete this node!')}>
+              {itemConfig.contact && !this.state.incidentContacts.find(contact => contact.parent === itemConfig.id) ? <button onClick={() => console.log('delete this node!')}>
                 <AiOutlineDelete />
-              </button>}
+              </button> : null}
               {itemConfig.contact && <button onClick={() => this.setState({ addNode: { isVisible: true, parent: itemConfig } })}>
                 <AiOutlineCluster />
               </button>}

--- a/src/components/ChartEditor/ChartEditor.js
+++ b/src/components/ChartEditor/ChartEditor.js
@@ -123,8 +123,94 @@ export default class ChartEditor extends Component {
   }
 
   refreshContacts() {
-    let workingArray = this.state.incidentContacts
-    workingArray.forEach(role => role.contact = null)
+    let workingArray = [
+      {
+        id: 0,
+        parent: null,
+        title: 'Incident Commander',
+        contact: null,
+        templateName: 'incident_commander',
+      },
+      {
+        id: 1,
+        parent: 0,
+        title: 'Liaison Officer',
+        contact: null,
+        itemType: ItemType.Assistant,
+        adviserPlacementType: AdviserPlacementType.Right,
+        templateName: 'command_staff',
+        isVisible: false
+      },
+      {
+        id: 2,
+        parent: 0,
+        title: 'Public Information Officer',
+        contact: null,
+        itemType: ItemType.Assistant,
+        adviserPlacementType: AdviserPlacementType.Left, 
+        templateName: 'command_staff',
+        isVisible: false 
+      },
+      {
+        id: 3,
+        parent: 0,
+        isVisible: false,
+        title: 'aggregator',
+        description: 'Invisible aggregator',
+        childrenPlacementType: ChildrenPlacementType.Horizontal
+      },
+      {
+        id: 4,
+        parent: 3,
+        title: 'Safety Officer',
+        contact: null,
+        itemType: ItemType.Assistant,
+        adviserPlacementType: AdviserPlacementType.Right,
+        hasButtons: Enabled.True,
+        templateName: 'command_staff',
+        isVisible: false
+      },
+      {
+        id: 5,
+        parent: 3,
+        isVisible: false,
+        title: 'aggregator',
+        description: 'Invisible aggregator 2',
+        childrenPlacementType: ChildrenPlacementType.Horizontal
+      },
+      {
+        id: 6,
+        parent: 5,
+        title: 'Operations Chief',
+        contact: null,
+        templateName: 'section_commander',
+        isVisible: false
+      },
+      {
+        id: 7,
+        parent: 5,
+        title: 'Logistics Chief',
+        contact: null,
+        templateName: 'section_commander',
+        isVisible: false
+      },
+      {
+        id: 8,
+        parent: 5,
+        title: 'Planning Chief',
+        contact: null,
+        templateName: 'section_commander',
+        isVisible: false
+      },
+      {
+        id: 9,
+        parent: 5,
+        title: 'Finance Chief',
+        contact: null,
+        templateName: 'section_commander',
+        isVisible: false
+      }
+    ]
     getIncidentContacts(this.state.incidentID)
     .then(data => data.contacts.map(contact => {
       let match = workingArray.find(role => role.id === contact.incident_role)
@@ -153,7 +239,7 @@ export default class ChartEditor extends Component {
   }
 
   render() {
-
+    console.log(this.state.incidentContacts)
     const config = {
       pageFitMode: PageFitMode.FitToPage,
       cursorItem: 0,
@@ -285,7 +371,7 @@ export default class ChartEditor extends Component {
               {itemConfig.contact && <button onClick={() => this.setState({ reassignMenu: { isVisible: true, role: itemConfig } })}>
                 <AiOutlineUserSwitch />
               </button>}
-              {itemConfig.contact && !this.state.incidentContacts.find(contact => contact.parent === itemConfig.id) ? <button onClick={() => console.log('delete this node!')}>
+              {itemConfig.contact && !this.state.incidentContacts.find(contact => contact.parent === itemConfig.id) ? <button onClick={() => this.setState({ unassignMenu: { isVisible: true, role: itemConfig } })}>
                 <AiOutlineDelete />
               </button> : null}
               {itemConfig.contact && <button onClick={() => this.setState({ addNode: { isVisible: true, parent: itemConfig } })}>
@@ -311,7 +397,7 @@ export default class ChartEditor extends Component {
           }} 
           animation={false} 
         />}
-        <UnassignMenu
+        {this.state.unassignMenu.isVisible && <UnassignMenu
           show={this.state.unassignMenu.isVisible}
           role={this.state.unassignMenu.role}
           onHide={() => {
@@ -319,7 +405,7 @@ export default class ChartEditor extends Component {
             this.refreshContacts()
           }}
           animation={false}         
-        />
+        />}
         {this.state.reassignMenu.isVisible && <ReassignMenu
           show={this.state.reassignMenu.isVisible}
           role={this.state.reassignMenu.role}

--- a/src/components/ChartEditor/ChartEditor.js
+++ b/src/components/ChartEditor/ChartEditor.js
@@ -11,10 +11,10 @@ import AddNode from '../AddNode/AddNode'
 import { returnContactAvatar } from '../../utils'
 
 export default class ChartEditor extends Component {
-  constructor({ incidentID }) {
+  constructor({ incident_id }) {
     super()
     this.state = {
-      incidentID: incidentID,
+      incident_id: incident_id,
       assignmentMenu: {
         isVisible: false,
         role: null
@@ -211,7 +211,7 @@ export default class ChartEditor extends Component {
         isVisible: false
       }
     ]
-    getIncidentContacts(this.state.incidentID)
+    getIncidentContacts(this.state.incident_id)
     .then(data => data.contacts.map(contact => {
       let match = workingArray.find(role => role.id === contact.incident_role)
       if (match) {
@@ -239,7 +239,6 @@ export default class ChartEditor extends Component {
   }
 
   render() {
-    console.log(this.state.incidentContacts)
     const config = {
       pageFitMode: PageFitMode.FitToPage,
       cursorItem: 0,
@@ -390,7 +389,7 @@ export default class ChartEditor extends Component {
         {this.state.assignmentMenu.isVisible && <AssignRoleMenu 
           show={this.state.assignmentMenu.isVisible} 
           role={this.state.assignmentMenu.role}
-          incidentID={this.state.incidentID}
+          incident_id={this.state.incident_id}
           onHide={() => {
             this.setState({ assignmentMenu: { isVisible: false, role: null } })
             this.refreshContacts()
@@ -409,7 +408,7 @@ export default class ChartEditor extends Component {
         {this.state.reassignMenu.isVisible && <ReassignMenu
           show={this.state.reassignMenu.isVisible}
           role={this.state.reassignMenu.role}
-          incidentID={this.state.incidentID}
+          incident_id={this.state.incident_id}
           onHide={() => {
             this.setState({ reassignMenu: { isVisible: false, role: null } })
             this.refreshContacts()
@@ -423,7 +422,7 @@ export default class ChartEditor extends Component {
             this.refreshContacts()
           }}
           parent={this.state.addNode.parent}
-          incidentID={this.state.incidentID}
+          incident_id={this.state.incident_id}
           animation={false}
         />}
       </div>

--- a/src/components/ChartEditor/ChartEditor.js
+++ b/src/components/ChartEditor/ChartEditor.js
@@ -240,7 +240,7 @@ export default class ChartEditor extends Component {
 
   render() {
     const config = {
-      pageFitMode: PageFitMode.FitToPage,
+      pageFitMode: PageFitMode.None,
       cursorItem: 0,
       highlightItem: 0,
       arrowsDirection: GroupByType.Children,
@@ -250,17 +250,16 @@ export default class ChartEditor extends Component {
       templates: [
         {
           name: 'incident_commander',
-          itemSize: { width: 220, height: 150 },
+          itemSize: { width: 300, height: 140 },
           onItemRender: ({ context: itemConfig }) => {
             return (
               <div className="ContactTemplate">
                 <div className="ContactTitleBackground">
-                  <div className="ContactTitle">{itemConfig.title}</div>
-                </div>
-                <div className="ContactPhotoFrame">
+                  <h4 className="ContactTitle">{itemConfig.title}</h4>
                   {itemConfig.contact ? returnContactAvatar(itemConfig.contact.contact_type) : null}
                 </div>
-                <div className="ContactDescription">{itemConfig.contact ? itemConfig.contact.name : 'Unassigned'}</div>
+                <h5 className="ContactDescription">{itemConfig.contact ? itemConfig.contact.name : 'Unassigned'}</h5>
+                <div className="ContactJob">{itemConfig.contact ? `${itemConfig.contact.jobtitle} - ${itemConfig.contact.organization}` : ''}</div>
                 <div className="ContactPhone">Phone: {itemConfig.contact ? itemConfig.contact.phone : ''}</div>
                 <div className="ContactEmail">Email: {itemConfig.contact ? itemConfig.contact.email : ''}</div>
               </div> 
@@ -279,17 +278,16 @@ export default class ChartEditor extends Component {
         },
         {
           name: 'command_staff',
-          itemSize: { width: 220, height: 150 },
+          itemSize: { width: 300, height: 140 },
           onItemRender: ({ context: itemConfig }) => {
             return (
               <div className={itemConfig.contact ? 'ContactTemplate' : 'UnassignedContactTemplate'}>
                 <div className="ContactTitleBackground">
-                  <div className="ContactTitle">{itemConfig.title}</div>
-                </div>
-                <div className="ContactPhotoFrame">
+                  <h4 className="ContactTitle">{itemConfig.title}</h4>
                   {itemConfig.contact ? returnContactAvatar(itemConfig.contact.contact_type) : null}
                 </div>
-                <div className="ContactDescription">{itemConfig.contact ? itemConfig.contact.name : 'Unassigned'}</div>
+                <h5 className="ContactDescription">{itemConfig.contact ? itemConfig.contact.name : 'Unassigned'}</h5>
+                <div className="ContactJob">{itemConfig.contact ? `${itemConfig.contact.jobtitle} - ${itemConfig.contact.organization}` : ''}</div>
                 <div className="ContactPhone">Phone: {itemConfig.contact ? itemConfig.contact.phone : ''}</div>
                 <div className="ContactEmail">Email: {itemConfig.contact ? itemConfig.contact.email : ''}</div>
               </div> 
@@ -311,17 +309,16 @@ export default class ChartEditor extends Component {
         },
         {
           name: 'section_commander',
-          itemSize: { width: 220, height: 150 },
+          itemSize: { width: 300, height: 140 },
           onItemRender: ({ context: itemConfig }) => {
             return (
               <div className={itemConfig.contact ? 'ContactTemplate' : 'UnassignedContactTemplate'}>
                 <div className="ContactTitleBackground">
-                  <div className="ContactTitle">{itemConfig.title}</div>
-                </div>
-                <div className="ContactPhotoFrame">
+                  <h4 className="ContactTitle">{itemConfig.title}</h4> 
                   {itemConfig.contact ? returnContactAvatar(itemConfig.contact.contact_type) : null}
-                </div>
-                <div className="ContactDescription">{itemConfig.contact ? itemConfig.contact.name : 'Unassigned'}</div>
+              </div>                  
+                <h5 className="ContactDescription">{itemConfig.contact ? itemConfig.contact.name : 'Unassigned'}</h5>
+                <div className="ContactJob">{itemConfig.contact ? `${itemConfig.contact.jobtitle} - ${itemConfig.contact.organization}` : ''}</div>
                 <div className="ContactPhone">Phone: {itemConfig.contact ? itemConfig.contact.phone : ''}</div>
                 <div className="ContactEmail">Email: {itemConfig.contact ? itemConfig.contact.email : ''}</div>
               </div> 
@@ -346,17 +343,16 @@ export default class ChartEditor extends Component {
         },
         {
           name: 'section_node',
-          itemSize: { width: 220, height: 150 },
+          itemSize: { width: 300, height: 140 },
           onItemRender: ({ context: itemConfig }) => {
             return (
               <div className={itemConfig.contact ? 'ContactTemplate' : 'UnassignedContactTemplate'}>
                 <div className="ContactTitleBackground">
-                  <div className="ContactTitle">{itemConfig.title}</div>
-                </div>
-                <div className="ContactPhotoFrame">
+                  <h4 className="ContactTitle">{itemConfig.title}</h4>
                   {itemConfig.contact ? returnContactAvatar(itemConfig.contact.contact_type) : null}
                 </div>
-                <div className="ContactDescription">{itemConfig.contact ? itemConfig.contact.name : 'Unassigned'}</div>
+                <h5 className="ContactDescription">{itemConfig.contact ? itemConfig.contact.name : 'Unassigned'}</h5>
+                {itemConfig.contact && <div className="ContactJob">{itemConfig.contact.contact_type === 'Person' ? `${itemConfig.contact.jobtitle} - ${itemConfig.contact.organization}` : `${itemConfig.contact.point_of_contact} - ${itemConfig.contact.point_of_contact_title}, ${itemConfig.contact.organization}`}</div>}
                 <div className="ContactPhone">Phone: {itemConfig.contact ? itemConfig.contact.phone : ''}</div>
                 <div className="ContactEmail">Email: {itemConfig.contact ? itemConfig.contact.email : ''}</div>
               </div> 

--- a/src/components/IncidentManager/IncidentManager.js
+++ b/src/components/IncidentManager/IncidentManager.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { getIncidentBySlug } from '../../api-calls'
 import ChartEditor from '../ChartEditor/ChartEditor'
 
@@ -16,6 +17,8 @@ const IncidentManager = ({ slug }) => {
       <h1>{incident.name}</h1>
       <h4>{incident.incident_type} | {incident.location} | ACTIVE SINCE: {incident.created_at}</h4>
       <p>{incident.summary}</p>
+      <Link to='/dashboard'><button>BACK</button></Link>
+      <button>RESOLVE</button>
       {incident.id && <ChartEditor incident_id={incident.id} />}
     </div>
   )

--- a/src/components/IncidentManager/IncidentManager.js
+++ b/src/components/IncidentManager/IncidentManager.js
@@ -16,7 +16,7 @@ const IncidentManager = ({ slug }) => {
       <h1>{incident.name}</h1>
       <h4>{incident.incident_type} | {incident.location} | ACTIVE SINCE: {incident.created_at}</h4>
       <p>{incident.summary}</p>
-      {incident.id && <ChartEditor incidentID={incident.id} />}
+      {incident.id && <ChartEditor incident_id={incident.id} />}
     </div>
   )
 }

--- a/src/components/ReassignMenu/ReassignMenu.js
+++ b/src/components/ReassignMenu/ReassignMenu.js
@@ -38,7 +38,6 @@ const ReassignMenu = (props) => {
     .then(response => {
       if (response[0].status === "updated" && response[1].status === "updated") {
         setSelectedContact(null)
-        // refreshContacts()
         props.onHide()
       }
     })

--- a/src/components/ReassignMenu/ReassignMenu.js
+++ b/src/components/ReassignMenu/ReassignMenu.js
@@ -5,20 +5,18 @@ import { getAllContacts, updateContactAssignment } from '../../api-calls'
 import { returnContactAvatar } from '../../utils'
 
 const ReassignMenu = (props) => {
-  console.log(props)
   const [availableContacts, setAvailableContacts] = useState([])
   const [selectedContact, setSelectedContact] = useState(null)
   const [searchQuery, setSearchQuery] = useState('')
   const userID = useSelector(state => state.user.user.id)
-  
-  const refreshContacts = () => {
-    getAllContacts(userID)
-    .then(response => setAvailableContacts(response.contacts.filter(contact => contact.incident_id === null && contact.contact_type === 'Person')))
-  }
 
   useEffect(() => {
+    const refreshContacts = () => {
+      getAllContacts(userID)
+      .then(response => setAvailableContacts(response.contacts.filter(contact => contact.incident_id === null && contact.contact_type === 'Person')))
+    }  
     refreshContacts()
-  }, [])
+  }, [userID])
 
   const compileAvailableContacts = (qry) => {
     return availableContacts.filter(contact => {
@@ -34,13 +32,13 @@ const ReassignMenu = (props) => {
 
   const reassignContact = () => {
     Promise.all([
-      updateContactAssignment(selectedContact.id, props.role.id, props.incidentID),
+      updateContactAssignment(selectedContact.id, props.role.id, props.incident_id),
       updateContactAssignment(props.role.contact.id, null, null) 
     ])
     .then(response => {
       if (response[0].status === "updated" && response[1].status === "updated") {
         setSelectedContact(null)
-        refreshContacts()
+        // refreshContacts()
         props.onHide()
       }
     })

--- a/src/components/ReassignMenu/ReassignMenu.js
+++ b/src/components/ReassignMenu/ReassignMenu.js
@@ -32,8 +32,8 @@ const ReassignMenu = (props) => {
 
   const reassignContact = () => {
     Promise.all([
-      updateContactAssignment(selectedContact.id, props.role.id, props.incident_id),
-      updateContactAssignment(props.role.contact.id, null, null) 
+      updateContactAssignment(selectedContact.id, props.role.id, props.incident_id, props.role.parent, props.role.title),
+      updateContactAssignment(props.role.contact.id, null, null, null, null) 
     ])
     .then(response => {
       if (response[0].status === "updated" && response[1].status === "updated") {

--- a/src/components/UnassignMenu/UnassignMenu.js
+++ b/src/components/UnassignMenu/UnassignMenu.js
@@ -7,7 +7,7 @@ const UnassignMenu = (props) => {
   
   const unassignContact = () => {
 
-    updateContactAssignment(props.role.contact.id, null, null)
+    updateContactAssignment(props.role.contact.id, null, null, null, null)
     .then(response => {
       if (response.status === 'updated') {
         props.onHide()

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,5 +23,7 @@ export const returnContactAvatar = (contactType) => {
       return <GiCrane />
     case 'Animal':
       return <GiSittingDog />
+    default:
+      return <AiOutlineUser />
   }
 }


### PR DESCRIPTION
* This PR chiefly adds the ability to delete custom nodes from the four sections of the chart editor.
* It also addresses several warnings and errors that were appearing on the console
* Minor styling adjustments display more contact data on the chart nodes
* Adds a back button to the incident manager for improved navigability.
* The Chart Editor is now fully functional and needs only styling improvements. Next I will build the press release editor before moving onto the public facing page. However, I think this PR achieves MVP so it may be wise to first integrate Travis CI and deploy the site to Heroku with some initial testing.